### PR TITLE
Fix docker-compose server volume paths

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - .server/uploads:/app/uploads  # <-- Tippfehler hier
-      - .server/output:/app/output   # <-- Tippfehler hier
-      - .server/templates:/app/templates # <-- Tippfehler hier
+      - ./server/uploads:/app/uploads
+      - ./server/output:/app/output
+      - ./server/templates:/app/templates
     environment:
       - SECRET_KEY=${SECRET_KEY:-change-me-in-production}
       - ADMIN_USERNAME=${ADMIN_USERNAME:-admin}


### PR DESCRIPTION
## Summary
- fix typos in server volume paths within `docker-compose.yml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6853d67c2990832db55cdb54dbbe0f41