### PR TITLE
Fix n8n configuration behind reverse proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,8 +60,10 @@ services:
       - "5678:5678"
     environment:
       - N8N_BASIC_AUTH_ACTIVE=false
-      - N8N_SECURE_COOKIE=fasle
-      - WEBHOOK_URL=http://10.254.64.14:5678
+      - N8N_SECURE_COOKIE=false
+      - N8N_EDITOR_BASE_URL=https://10.254.64.14/n8n/
+      - WEBHOOK_URL=https://10.254.64.14/n8n/
+      - N8N_PATH=/n8n
     volumes:
       - n8n_data:/home/node/.n8n
     restart: always

--- a/docs/n8n.md
+++ b/docs/n8n.md
@@ -4,7 +4,7 @@ Diese Anleitung beschreibt, wie eine n8n-Instanz zusammen mit der bestehenden dx
 
 ## Docker Compose
 
-Der `docker-compose.yml` enthält bereits einen Service `n8n`. Nach dem Start steht die Weboberfläche unter `http://localhost:5678` zur Verfügung.
+Der `docker-compose.yml` enthält bereits einen Service `n8n`. In der Standardkonfiguration wird der Dienst über den Nginx‑Proxy bereitgestellt und ist anschließend unter `https://10.254.64.14/n8n/` erreichbar.
 
 ```
 docker compose up --build

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -39,6 +39,14 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        location /n8n/ {
+            proxy_pass http://n8n:5678/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         location / {
             proxy_pass http://client:80/;
             proxy_set_header Host $host;


### PR DESCRIPTION
## Summary
- configure n8n service with sub path and correct environment variables
- proxy requests to `/n8n` through nginx
- update the n8n docs to reflect new URL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6853d8377fa0832db311b50a959ae3a7