### PR TITLE
Fix import error when QGIS is missing

### DIFF
--- a/server/convert_dxf_to_geopdf.py
+++ b/server/convert_dxf_to_geopdf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 import os
 import logging


### PR DESCRIPTION
## Summary
- avoid evaluating QGIS type hints at runtime by enabling postponed annotations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6853da9f6b24832d8d8e7c67dd5b5716