### PR TITLE
Fix n8n path documentation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       - N8N_SECURE_COOKIE=false
       - N8N_EDITOR_BASE_URL=https://10.254.64.14/n8n/
       - WEBHOOK_URL=https://10.254.64.14/n8n/
-      - N8N_PATH=/n8n
+      - N8N_PATH=/n8n/
     volumes:
       - n8n_data:/home/node/.n8n
     restart: always

--- a/docs/n8n.md
+++ b/docs/n8n.md
@@ -6,6 +6,8 @@ Diese Anleitung beschreibt, wie eine n8n-Instanz zusammen mit der bestehenden dx
 
 Der `docker-compose.yml` enthält bereits einen Service `n8n`. In der Standardkonfiguration wird der Dienst über den Nginx‑Proxy bereitgestellt und ist anschließend unter `https://10.254.64.14/n8n/` erreichbar.
 
+Wichtig ist, dass die Umgebungsvariable `N8N_PATH` mit einem abschließenden Schrägstrich gesetzt wird (z.B. `N8N_PATH=/n8n/`). Ohne das `/` am Ende sucht n8n nach statischen Dateien unter `/n8nassets` und die Oberfläche lädt nicht korrekt.
+
 ```
 docker compose up --build
 ```


### PR DESCRIPTION
## Summary
- document that `N8N_PATH` must end with a slash so static files load properly
- update compose file accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6853db6ee6f8832dace57a55edb304ea