### PR TITLE
Fix client login to call API

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -20,13 +20,19 @@ function Login({ onLogin }) {
     setError('')
 
     try {
-      // Simulate login - replace with actual API call
-      if (username === 'admin' && password === 'admin123') {
-        // Simulate token generation
-        const token = btoa(`${username}:${Date.now()}`)
-        onLogin(token)
-      } else {
+      const res = await fetch(`${API}/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      })
+
+      if (res.ok) {
+        const data = await res.json()
+        onLogin(data.access_token)
+      } else if (res.status === 401) {
         setError('Ungültige Anmeldedaten')
+      } else {
+        setError('Anmeldefehler aufgetreten')
       }
     } catch (err) {
       setError('Anmeldefehler aufgetreten')

--- a/client/src/components/Login.jsx
+++ b/client/src/components/Login.jsx
@@ -1,6 +1,8 @@
 import { useState } from 'react'
 import { Lock } from 'lucide-react'
 
+const API = '/api'
+
 export default function Login({ onLogin }) {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
@@ -13,13 +15,19 @@ export default function Login({ onLogin }) {
     setError('')
 
     try {
-      // Simulate login - replace with actual API call
-      if (username === 'admin' && password === 'admin123') {
-        // Simulate token generation
-        const token = btoa(`${username}:${Date.now()}`)
-        onLogin(token)
-      } else {
+      const res = await fetch(`${API}/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      })
+
+      if (res.ok) {
+        const data = await res.json()
+        onLogin(data.access_token)
+      } else if (res.status === 401) {
         setError('Ungültige Anmeldedaten')
+      } else {
+        setError('Anmeldefehler aufgetreten')
       }
     } catch (err) {
       setError('Anmeldefehler aufgetreten')


### PR DESCRIPTION
## Summary
- authenticate using the API `/login` endpoint instead of a dummy token
- update unused Login component with the same behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6853dccaaa4c832d89a19b9d95f08b41