### PR TITLE
Add bagmaptiler container and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,6 @@ server containers.
 Eine ausführlichere Beschreibung des Projekts befindet sich in [docs/overview.md](docs/overview.md).
 Eine Anleitung zur Nutzung eines MapTiler-Engine-Containers zur alternativen
 Kachelerzeugung findet sich in [docs/maptiler.md](docs/maptiler.md).
+Hinweise zur eigenen GDAL-basierten Engine stehen in [docs/bagmaptiler.md](docs/bagmaptiler.md).
 Eine kurze Einführung zur Automatisierung mit n8n ist unter
 [docs/n8n.md](docs/n8n.md) zu finden.

--- a/bagmaptiler/Dockerfile
+++ b/bagmaptiler/Dockerfile
@@ -1,0 +1,11 @@
+FROM osgeo/gdal:alpine-small-latest
+
+RUN apk add --no-cache python3 py3-pip bash && \
+    pip install mbutil && \
+    chmod +x /usr/bin/gdal2tiles.py
+
+COPY entrypoint.sh /usr/local/bin/maptiler
+RUN chmod +x /usr/local/bin/maptiler
+
+WORKDIR /data
+ENTRYPOINT ["maptiler"]

--- a/bagmaptiler/entrypoint.sh
+++ b/bagmaptiler/entrypoint.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+set -e
+
+INPUT=$1
+OUTPUT=$2
+SRS=$3
+ZOOMMIN=$4
+ZOOMMAX=$5
+FORMAT=$6    # png, jpeg, webp
+STORE=$7     # dir, mbtiles
+
+FILENAME=$(basename "$INPUT")
+EXT="${FILENAME##*.}"
+BASENAME="${FILENAME%.*}"
+TIFF="/tmp/${BASENAME}.tif"
+
+echo ">> [1/6] Konvertierung nach GeoTIFF…"
+if [[ "$EXT" == "pdf" ]]; then
+    gdal_translate "$INPUT" "$TIFF"
+elif [[ "$EXT" == "dxf" ]]; then
+    ogr2ogr -f GPKG temp.gpkg "$INPUT"
+    gdal_translate temp.gpkg "$TIFF"
+elif [[ "$EXT" == "tif" || "$EXT" == "tiff" ]]; then
+    cp "$INPUT" "$TIFF"
+else
+    echo "Nicht unterstütztes Eingabeformat: $EXT"
+    exit 1
+fi
+
+echo ">> [2/6] Reprojektion nach $SRS…"
+WARPED="/tmp/${BASENAME}_warped.tif"
+gdalwarp -t_srs "$SRS" "$TIFF" "$WARPED"
+
+echo ">> [3/6] Erzeuge Tiles…"
+mkdir -p "$OUTPUT"
+gdal2tiles.py \
+    -z "$ZOOMMIN"-"$ZOOMMAX" \
+    --processes=4 \
+    --resampling=bilinear \
+    --webviewer=none \
+    --tile-format="$FORMAT" \
+    "$WARPED" "$OUTPUT"
+
+if [[ "$STORE" == "mbtiles" ]]; then
+    echo ">> [4/6] Erzeuge MBTiles…"
+    mb-util --image_format="$FORMAT" --scheme=osm "$OUTPUT" "${OUTPUT}.mbtiles"
+fi
+
+echo ">> [5/6] Generiere config.json…"
+RES=$(gdalinfo "$WARPED" | grep "Pixel Size" | grep -oP '\(\K[^\s,]+')
+EXTENT=($(gdalinfo "$WARPED" | grep "Lower Left" -A1 | grep -oE "[0-9]+\.[0-9]+"))
+BBOX_MINX=${EXTENT[0]}
+BBOX_MINY=${EXTENT[1]}
+BBOX_MAXX=${EXTENT[2]}
+BBOX_MAXY=${EXTENT[3]}
+SRSNAME="$SRS"
+
+cat <<EOF2 > "$OUTPUT/config.json"
+{
+  "resolution": $RES,
+  "maxzoom": $ZOOMMAX,
+  "minzoom": $ZOOMMIN,
+  "comments": "",
+  "srs": "$SRSNAME",
+  "bounds": [$BBOX_MINX, $BBOX_MINY, $BBOX_MAXX, $BBOX_MAXY]
+}
+EOF2
+
+echo ">> [6/6] Generiere openlayers.html…"
+cat <<EOF2 > "$OUTPUT/openlayers.html"
+<!DOCTYPE html>
+<html>
+<head>
+<title>$BASENAME</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style>html, body {margin:0;height:100%;} #map {width:100%;height:100%;}</style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.8.2/ol.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/ol3/3.8.2/ol.min.js"></script>
+</head>
+<body>
+<div id="map"></div>
+<script>
+var mapExtent = [$BBOX_MINX, $BBOX_MINY, $BBOX_MAXX, $BBOX_MAXY];
+var mapMinZoom = $ZOOMMIN;
+var mapMaxZoom = $ZOOMMAX;
+var mapMaxResolution = $RES;
+var tileExtent = mapExtent;
+var mapResolutions = [];
+for (var z = mapMinZoom; z <= mapMaxZoom; z++) {
+  mapResolutions.push(Math.pow(2, mapMaxZoom - z) * mapMaxResolution);
+}
+var mapTileGrid = new ol.tilegrid.TileGrid({
+  extent: tileExtent,
+  minZoom: mapMinZoom,
+  resolutions: mapResolutions
+});
+var map = new ol.Map({
+  target: 'map',
+  layers: [ new ol.layer.Tile({
+    source: new ol.source.XYZ({
+      projection: '$SRSNAME',
+      tileGrid: mapTileGrid,
+      url: "{z}/{x}/{y}.$FORMAT"
+    })
+  })],
+  view: new ol.View({
+    projection: ol.proj.get('$SRSNAME'),
+    extent: mapExtent,
+    maxResolution: mapTileGrid.getResolution(mapMinZoom)
+  })
+});
+map.getView().fit(mapExtent, map.getSize());
+</script>
+</body>
+</html>
+EOF2
+
+echo "✅ Tile-Export abgeschlossen: $OUTPUT"

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Dieses Verzeichnis enthält alle weiterführenden Informationen zum Projekt **dx
 
 * [Projektübersicht](overview.md) – beschreibt die Komponenten (FastAPI-Server, React-Client, Nginx) und führt durch den Schnellstart.
 * [MapTiler Engine](maptiler.md) – Nutzung eines optionalen Containers zur Kachelgenerierung.
+* [BagMapTiler](bagmaptiler.md) – eigene GDAL-basierte Engine für Tiles.
 * [n8n Automatisierung](n8n.md) – Beispielhafte Einbindung eines n8n-Workflows.
 
 ## Entwicklung

--- a/docs/bagmaptiler.md
+++ b/docs/bagmaptiler.md
@@ -1,0 +1,73 @@
+# Eigene Kachel-Engine "bagmaptiler"
+
+Dieses Docker-Image erzeugt TMS-Kacheln oder MBTiles ausschließlich mit den
+Open‑Source-Werkzeugen von GDAL. Es kann GeoPDF-, DXF- und GeoTIFF-Dateien
+verarbeiten und legt zusätzlich eine `config.json` sowie eine einfache
+Vorschau-HTML ab.
+
+## Dockerfile
+
+```Dockerfile
+FROM osgeo/gdal:alpine-small-latest
+
+RUN apk add --no-cache python3 py3-pip bash && \
+    pip install mbutil && \
+    chmod +x /usr/bin/gdal2tiles.py
+
+COPY entrypoint.sh /usr/local/bin/maptiler
+RUN chmod +x /usr/local/bin/maptiler
+
+WORKDIR /data
+ENTRYPOINT ["maptiler"]
+```
+
+## Entry-Script `entrypoint.sh`
+
+```bash
+#!/bin/bash
+set -e
+
+INPUT=$1
+OUTPUT=$2
+SRS=$3
+ZOOMMIN=$4
+ZOOMMAX=$5
+FORMAT=$6    # png, jpeg, webp
+STORE=$7     # dir, mbtiles
+
+# ... gekürzter Inhalt, siehe Repository
+```
+
+Das Skript konvertiert die Eingabedatei zunächst nach GeoTIFF, reprojiziert sie
+in das gewünschte Koordinatensystem und ruft anschließend `gdal2tiles.py` auf.
+Optional werden die Tiles mit `mb-util` zu einer MBTiles-Datei gebündelt.
+
+Am Ende werden `config.json` und `openlayers.html` erzeugt.
+
+## Beispiel-Aufruf
+
+```bash
+docker run --rm \
+  -v $(pwd)/input:/data/upload \
+  -v $(pwd)/output:/data/tiles \
+  myorg/bagmaptiler \
+  /data/upload/zuerich.pdf /data/tiles/zuerich EPSG:2056 3 7 png dir
+```
+
+Die Ergebnisstruktur entspricht dabei:
+
+```
+/output/zuerich/
+├── 3/
+├── 4/
+├── ...
+├── config.json
+└── openlayers.html
+```
+
+## ToDos
+
+- Image bauen: `docker build -t myorg/bagmaptiler .`
+- SSH-Konfiguration einrichten
+- Upload- und Output-Verzeichnisse anlegen
+- In bestehende Workflows integrieren

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -73,3 +73,10 @@ Zur Validierung der TMS-Kachelgenerierung kann optional der proprietäre
 MapTiler-Engine-Container von Kloakan Tech genutzt werden. Hinweise zur
 Einbindung finden sich in [docs/maptiler.md](maptiler.md).
 
+## BagMapTiler
+
+Als vollständig quelloffene Alternative steht das Docker-Image
+`bagmaptiler` bereit. Es verwendet ausschließlich GDAL-Werkzeuge, um aus
+GeoPDF-, DXF- oder TIFF-Dateien XYZ-Kacheln oder MBTiles zu erzeugen.
+Details zur Verwendung befinden sich in [docs/bagmaptiler.md](bagmaptiler.md).
+


### PR DESCRIPTION
## Summary
- add `bagmaptiler` folder with Dockerfile and entrypoint
- document new bagmaptiler container usage
- link new docs from README and overview

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68638310ef14832d96f2d7a18fb0b992