### PR TITLE
Add runner status monitor to sidebar

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,6 +10,7 @@ import {
   MapPin,
   Navigation,
   Layers,
+  Activity,
   Menu,
   X,
   BookOpen
@@ -17,6 +18,7 @@ import {
 import Map from './components/Map.jsx' // Import der Map Komponente
 import ServiceTaskManager from './components/ServiceTaskManager.jsx';
 import ContainerMonitor from './components/ContainerMonitor.jsx';
+import RunnerStatusMonitor from './components/RunnerStatusMonitor.jsx';
 import Login from './components/Login';
 import TmsPreviewDialog from './components/TmsPreviewDialog.jsx';
 import FileBrowser from './components/FileBrowser.jsx';
@@ -467,6 +469,7 @@ function App() {
     { id: 'n8n', label: 'n8n Workflow', icon: Layers },
     { id: 'service-task-manager', label: 'Service Task Manager', icon: Layers },
     { id: 'container-monitor', label: 'Container Monitor', icon: Layers },
+    { id: 'runner-status-monitor', label: 'Runner Status Monitor', icon: Activity },
     { id: 'api-docs', label: 'API Docs', icon: BookOpen },
   ]
 
@@ -887,14 +890,21 @@ function App() {
             />
           )}
           {page === 'container-monitor' && (
-            <ContainerMonitor 
-              api={API} 
-              token={token} 
-              addMessage={addMessage} 
-              dockerContainers={dockerContainers} 
-              dockerImages={dockerImages} 
-              dockerVolumes={dockerVolumes} 
-              fetchDockerServices={fetchDockerServices} 
+            <ContainerMonitor
+              api={API}
+              token={token}
+              addMessage={addMessage}
+              dockerContainers={dockerContainers}
+              dockerImages={dockerImages}
+              dockerVolumes={dockerVolumes}
+              fetchDockerServices={fetchDockerServices}
+            />
+          )}
+          {page === 'runner-status-monitor' && (
+            <RunnerStatusMonitor
+              api={API}
+              token={token}
+              addMessage={addMessage}
             />
           )}
         </main>

--- a/client/src/components/RunnerStatusMonitor.jsx
+++ b/client/src/components/RunnerStatusMonitor.jsx
@@ -1,0 +1,66 @@
+import { useState, useEffect } from 'react'
+import { RefreshCw } from 'lucide-react'
+
+const RunnerStatusMonitor = ({ api = '/api', token, addMessage }) => {
+  const [runners, setRunners] = useState([])
+
+  const fetchStatus = async () => {
+    if (!token) return
+    try {
+      const res = await fetch(`${api}/runners/status`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+      })
+      if (res.ok) {
+        setRunners(await res.json())
+      } else {
+        throw new Error(`HTTP ${res.status}`)
+      }
+    } catch (err) {
+      console.error('Failed to fetch runner status', err)
+      addMessage && addMessage('Fehler beim Laden der Runner-Status', 'error')
+    }
+  }
+
+  useEffect(() => {
+    fetchStatus()
+  }, [token])
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-bold text-gray-900">Runner Status Monitor</h2>
+        <button
+          onClick={fetchStatus}
+          className="flex items-center gap-2 px-3 py-1 rounded bg-blue-600 text-white hover:bg-blue-700"
+        >
+          <RefreshCw className="w-4 h-4" /> Refresh
+        </button>
+      </div>
+      <table className="min-w-full bg-white rounded shadow divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-4 py-2 text-left text-sm font-medium text-gray-700">Name</th>
+            <th className="px-4 py-2 text-left text-sm font-medium text-gray-700">Status</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200">
+          {runners.map((r) => (
+            <tr key={r.id || r.name}>
+              <td className="px-4 py-2">{r.name}</td>
+              <td className="px-4 py-2">{r.status}</td>
+            </tr>
+          ))}
+          {runners.length === 0 && (
+            <tr>
+              <td colSpan="2" className="px-4 py-2 text-center text-gray-500">
+                Keine Daten verfügbar
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default RunnerStatusMonitor


### PR DESCRIPTION
## Summary
- add RunnerStatusMonitor component
- link new page in sidebar navigation
- display RunnerStatusMonitor page when selected

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6863e762efc0832d895c8cfee2bcb26e